### PR TITLE
Resolves runtime errors with generarated initializers/referrari.rb file

### DIFF
--- a/lib/generators/referrari/templates/referrari_initializer.rb
+++ b/lib/generators/referrari/templates/referrari_initializer.rb
@@ -1,3 +1,2 @@
 Referrari.configure do |config|
-  # TODO: Add defaults here
 end

--- a/lib/referrari.rb
+++ b/lib/referrari.rb
@@ -1,4 +1,6 @@
-require "referrari/engine"
-
 module Referrari
 end
+
+# load referrari components
+require "referrari/config"
+require "referrari/engine"

--- a/lib/referrari/config.rb
+++ b/lib/referrari/config.rb
@@ -1,0 +1,23 @@
+require 'active_support/configurable'
+
+module Referrari
+
+  def self.configure(&block)
+    yield @config ||= Referrari::Configuration.new
+  end
+
+  def self.config
+    @config
+  end
+
+  class Configuration
+    include ActiveSupport::Configurable
+    config_accessor :example_setting # An example of defining a config property
+  end
+
+  # Set default values for config properties
+  configure do |config|
+    config.example_setting = "example value"
+  end
+
+end


### PR DESCRIPTION
This resolves issue #10
 * Added config.rb defining a Configurable
 * Removed comment in referrari_initializer about setting defaults
 * Require new config file from main referrari.rb
 * Require engine.rb after module Referrari is initially defined